### PR TITLE
Change the way the icon is loaded since it improves performance

### DIFF
--- a/neighborhood/templates/neighborhoods/index.html
+++ b/neighborhood/templates/neighborhoods/index.html
@@ -27,7 +27,7 @@
               <h2>{{ neighborhood.name }}</h2>
               <p>{{ neighborhood.borough }}</p>
             </div>
-            <p>{%bs_icon 'arrow-right' size='1.5rem' %}</p>
+            <p><img src="{% static 'bootstrap_icons/arrow-right.svg' size='1.5rem' %}" alt="arrow" /></p>
           </a>
         </div>
         {% endfor %}

--- a/static/bootstrap_icons/arrow-right.svg
+++ b/static/bootstrap_icons/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-right" viewBox="0 0 24 24">
+  <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8z"/>
+</svg>


### PR DESCRIPTION
https://github.com/gcivil-nyu-org/INET-Monday-Spring2023-Team-5/pull/110 into develop branch

Thanks @moringspeaker for finding the issue and opening the PR

Closes https://github.com/gcivil-nyu-org/INET-Monday-Spring2023-Team-5/pull/110 #118 


<img width="1579" alt="Screenshot 2023-04-10 at 8 43 26 PM" src="https://user-images.githubusercontent.com/25265451/231026411-eecfd021-ee24-4b2b-bb8f-1a375ae1a79c.png">

The performance has significantly improved a lot (from 14 seconds to 2 seconds)!! 